### PR TITLE
[18.0][FIX] tms: Two fields (group_tms_uom, group_uom) of res.config.settings() have the same label

### DIFF
--- a/tms/models/res_config_settings.py
+++ b/tms/models/res_config_settings.py
@@ -33,7 +33,7 @@ class ResConfigSettings(models.TransientModel):
     )
 
     group_tms_uom = fields.Boolean(
-        string="Units of Measure", implied_group="uom.group_uom"
+        string="TMS Units of Measure", implied_group="uom.group_uom"
     )
 
     # Custom Fields

--- a/tms/views/res_config_settings.xml
+++ b/tms/views/res_config_settings.xml
@@ -14,14 +14,14 @@
                 >
                     <block title="Units" name="general_settings_container">
                         <setting id="tms_uom">
-                            <field name="group_tms_uom" string="Units of Measure" />
+                            <field name="group_tms_uom" string="TMS Units of Measure" />
                             <div class="content-group">
                                 <div class="mt8" invisible="not group_tms_uom">
                                     <button
                                         name="%(uom.product_uom_categ_form_action)d"
                                         icon="oi-arrow-right"
                                         type="action"
-                                        string="Units Of Measure"
+                                        string="TMS Units of Measure"
                                         class="btn-link"
                                     />
                                 </div>


### PR DESCRIPTION
Two fields (`group_tms_uom`, `group_uom`) of `res.config.settings()` have the same label: Units of Measure. [Modules: `tms` and `product`]